### PR TITLE
fix(update): add -P 15 to bbcp call

### DIFF
--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -438,7 +438,7 @@ def update_node_requests(node):
             # calculate the md5 hash as it goes, so we'll do that to save doing
             # it at the end.
             if command_available("bbcp"):
-                cmd = "bbcp -f -z --port 4200 -W 4M -s 16 -o -E md5= %s %s" % (
+                cmd = "bbcp -P 15 -f -z --port 4200 -W 4M -s 16 -o -E md5= %s %s" % (
                     from_path,
                     to_path,
                 )


### PR DESCRIPTION
This causes bbcp to output a progress message every 15 seconds.  The message doesn't show up anywhere, because alpenhorn captures and discards bbcp's stdout, but it does seem to stop the bbcp ssh connection from dying.