### PR TITLE
fix(alpenhornd): Several minor cluster-alpenhornd improvements

### DIFF
--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -188,10 +188,11 @@ def update_node_free_space(node):
     # Special case for cedar
     if node.host == "cedar5" and node.name == "cedar_online":
         # Strip non-numeric things
-        regexp = re.compile(r'[^\d ]+')
+        regexp = re.compile(r"[^\d ]+")
 
-        ret, stdout, stderr = run_command(["/usr/bin/lfs", "quota", "-q", "-g",
-                "rpp-chime", "/project"])
+        ret, stdout, stderr = run_command(
+            ["/usr/bin/lfs", "quota", "-q", "-g", "rpp-chime", "/project"]
+        )
         lfs_quota = regexp.sub("", stdout).split()
 
         # lfs quota reports values in kByte blocks

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -436,7 +436,7 @@ def update_node_requests(node):
             # calculate the md5 hash as it goes, so we'll do that to save doing
             # it at the end.
             if command_available("bbcp"):
-                cmd = "bbcp -P 15 -f -z --port 4200 -W 4M -s 16 -o -E md5= %s %s" % (
+                cmd = "bbcp -f -z --port 4200 -W 4M -s 16 -e -E %md5= %s %s" % (
                     from_path,
                     to_path,
                 )

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -185,6 +185,15 @@ def update_node_free_space(node):
     x = os.statvfs(node.root)
     node.avail_gb = float(x.f_bavail) * x.f_bsize / 2 ** 30.0
 
+    # Special case for cedar
+    if node.host == "cedar5" and node.name == "cedar_online":
+        ret, stdout, stderr = run_command(["/usr/bin/lfs", "quota", "-q", "-g",
+                "rpp-chime", "/project"])
+        lfs_quota = stdout.split()
+
+        # lfs quota reports values in kibibyte blocks
+        node.avail_gb = (int(lfs_quota[2]) - int(lfs_quota[1])) / 2 ** 20.0
+
     # Update the DB with the free space. Perform with an update query (rather
     # than save) to ensure we don't clobber changes made manually to the
     # database

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -485,6 +485,11 @@ def update_node_requests(node):
                 # MD5 sum as the source file, so we can skip the check here.
                 md5sum = req.file.md5sum if ret == 0 else None
 
+                # If the rsync error occured during `mkstemp` this is a
+                # problem on the destination, not the source
+                if ret and "mkstemp" in stderr:
+                    check_source_on_err = False
+
             # If we get here then we have no idea how to transfer the file...
             else:
                 log.warn("No commands available to complete this transfer.")

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -488,6 +488,7 @@ def update_node_requests(node):
                 # If the rsync error occured during `mkstemp` this is a
                 # problem on the destination, not the source
                 if ret and "mkstemp" in stderr:
+                    log.warn('rsync file creation failed on "{0}"'.format(node.name))
                     check_source_on_err = False
 
             # If we get here then we have no idea how to transfer the file...

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -187,12 +187,15 @@ def update_node_free_space(node):
 
     # Special case for cedar
     if node.host == "cedar5" and node.name == "cedar_online":
+        # Strip non-numeric things
+        regexp = re.compile(r'[^\d ]+')
+
         ret, stdout, stderr = run_command(["/usr/bin/lfs", "quota", "-q", "-g",
                 "rpp-chime", "/project"])
-        lfs_quota = stdout.split()
+        lfs_quota = regexp.sub("", stdout).split()
 
-        # lfs quota reports values in kibibyte blocks
-        node.avail_gb = (int(lfs_quota[2]) - int(lfs_quota[1])) / 2 ** 20.0
+        # lfs quota reports values in kByte blocks
+        node.avail_gb = (int(lfs_quota[1]) - int(lfs_quota[0])) / 2 ** 20.0
 
     # Update the DB with the free space. Perform with an update query (rather
     # than save) to ensure we don't clobber changes made manually to the

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -784,7 +784,7 @@ def update_node_hpss_inbound(node):
     if len(requests_to_process) == 0:
         return
 
-    if len(queued_archive_jobs()) > 1:
+    if len(queued_archive_jobs()) > 0:
         log.info("Skipping HPSS inbound as queue full.")
         return
 


### PR DESCRIPTION
A collection of small tweaks which I have made to the `alpenhornd`s on `cedar` and `niagara`:

## Changes to the `bbcp` command line options to try to avoid the `bbcp` stalls
* remove periodic progress output `-P 15`, which was some voodoo added as a guess that the cause of failed bbcp transfers was due to the process zombifying and/or the ssh session getting dropped
* remove output ordering `-o`, which I think was the actual cause of the stalls
* change checksum calculation so we don't need output ordering (see [the table](https://www.slac.stanford.edu/~abh/bbcp/#_Toc392015140)):
   * replace `-E md5=` with `-E %md5=` to calculate the checksum on the source, not the destination
   * add block-level checksums to re-introduce network transport check `-e`

## Reduce max allowed queued slurm jobs from 2 to 1.
Because alpenhorn has no memory, when the archivelong HPSS queue on niagara gets full and pull jobs take multiple hours to complete, then pulls for the same files tend to get enqueued multiple times.  Reducing the number of pending jobs should reduce the frequency at which this happens without significantly impacting throughput during times of no queue congestion

## Use `lfs quota` to get `cedar_online` free space
This shoe-horns-in a invocation of `lfs quota` to check the actual amount of space available on cedar `/project`.  On these lustre filesystems, the free block count from `statvfs` is pretty much meaningless.

Only done for `cedar_online` just to minimise the number of times the same quota is fetched.  (The call can take a few seconds to complete). 

Used to automatically adjust the cedar doomsday clock in Grafana. Also, when our usage drops below our quota, the usage number is suffixed by an asterisk to indicate that it's over quota.  So, we use a regex to filter out non-digits.

## When processing `ArchiveFileCopyRequests` handle "file copy already on target" before handling "file copy missing from source"

Originally these two checks were in the other order, and it was common on `niagara`, in times of queue congestion for a file to be deleted from `staging` after a successful HPSS push whilst a (second) copy request waited in the queue to be processed, leading to incessant "Skipping request since it is not available on node" messages resulting from the following sequence:
 * a file push to HPSS is created in a new `archivelong` job, and the the copy request is marked as complete
 * the `archivelong` job waits in the slurm queue for execution
 * the next hour, the same push-to-HPSS action is re-requested by the hourly "alpenhorn transfers" cron job by clearing the `completed` flag on the copy request.  This renewed request is not processed, because the slurm queue is full, and `alpenhornd` skips HPSS copy requests while it's full
 * the `archivelong` job is scheduled to execute and successfully copies the file into HPSS.  An archive file copy record is created for the file copy in HPSS.
 * because the HPSS file copy now exists, the source file is deleted from `scinet_staging`
 * eventually the `archivelong` queue empties and `alpenhornd` resumes processing HPSS copy requests, immediately tripping over the re-queued copy request for a file that is now missing fro `staging` (but on HPSS already).

The net harm from the old behaviour is nothing worse than spamming the alpenhornd log with error messages.  The resolution requires manually cancelling the erroneous copy requests.

With this change, these spurious requests are automatically cancelled by `alpenhornd`.

## When copies fail, don't force a check of source files which aren't the problem.
This stops alpenhornd from marking the source file suspect after a failed copy in certain obvious failures related to things not associated with the source file:
 * no method to do the copy is found (i.e. rsync is missing)
 * while hard-linking, something with the name already exists at the destination
 * `rsync` errors complaining about `mkstemp` which means the destination couldn't be created