### PR TITLE
fix: replace ConcurrentLogHandler with concurrent-log-handler

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -303,7 +303,7 @@ def status(all):
         [
             node[0],
             int(node[1]),
-            int(node[2]) / 2 ** 40.0,
+            int(node[2]) / 2**40.0,
             100.0 * int(node[1]) / int(tot[0]),
             100.0 * int(node[2]) / int(tot[1]),
             "%s:%s" % (node[3], node[4]),
@@ -597,7 +597,7 @@ def clean(node_name, days, size, force, now, target, acq):
                     .scalar()
                 )
 
-                size_gb = int(size_bytes) / 2 ** 30.0
+                size_gb = int(size_bytes) / 2**30.0
 
                 print(
                     "Cleaning up %i %s files (%.1f GB) from %s "
@@ -610,7 +610,7 @@ def clean(node_name, days, size, force, now, target, acq):
     elif size is not None:
 
         # Convert to bytes
-        size *= 2 ** 30
+        size *= 2**30
 
         # Iterate though the file list until we've found enough files
         marked_size = 0
@@ -633,7 +633,7 @@ def clean(node_name, days, size, force, now, target, acq):
         if count > 0:
             print(
                 "Cleaning up %i files (%.1f GB) from %s "
-                % (count, marked_size / 2 ** 30, node_name)
+                % (count, marked_size / 2**30, node_name)
             )
         else:
             print(

--- a/alpenhorn/logger.py
+++ b/alpenhorn/logger.py
@@ -14,12 +14,12 @@ import os
 
 # Use the concurrent logging file handler if we can
 try:
-    from cloghandler import ConcurrentRotatingFileHandler as RFHandler
+    from concurrent_log_handler import ConcurrentRotatingFileHandler as RFHandler
 except ImportError:
     # Next 2 lines are optional:  issue a warning to the user
     from warnings import warn
 
-    warn("ConcurrentLogHandler package not installed.  Using builtin log handler")
+    warn("concurrent-log-handler package not installed.  Using builtin log handler")
     from logging.handlers import RotatingFileHandler as RFHandler
 
 # Set up logger.

--- a/alpenhorn/logger.py
+++ b/alpenhorn/logger.py
@@ -43,7 +43,7 @@ if "ALPENHORN_LOG_FILE" in os.environ:
 
 # If log_path is set, set up as log handler
 if log_path != "":
-    log_file = RFHandler(log_path, maxBytes=(2 ** 22), backupCount=100)
+    log_file = RFHandler(log_path, maxBytes=(2**22), backupCount=100)
     log_file.setLevel(logging.INFO)
     log_file.setFormatter(log_fmt)
     _log.addHandler(log_file)

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -220,11 +220,11 @@ def update_node_free_space(node):
             quota = int(lfs_quota[1])
 
         # lfs quota reports values in kByte blocks
-        node.avail_gb = (quota - int(lfs_quota[0])) / 2 ** 20.0
+        node.avail_gb = (quota - int(lfs_quota[0])) / 2**20.0
     else:
         # Check with the OS how much free space there is
         x = os.statvfs(node.root)
-        node.avail_gb = float(x.f_bavail) * x.f_bsize / 2 ** 30.0
+        node.avail_gb = float(x.f_bavail) * x.f_bsize / 2**30.0
 
     # Update the DB with the free space. Perform with an update query (rather
     # than save) to ensure we don't clobber changes made manually to the
@@ -363,7 +363,7 @@ def update_node_requests(node):
         .where(di.ArchiveFileCopy.node == node, di.ArchiveFileCopy.has_file == "Y")
     )
     size = size_query.scalar(as_tuple=True)[0]
-    current_size_gb = float(0.0 if size is None else size) / 2 ** 30.0
+    current_size_gb = float(0.0 if size is None else size) / 2**30.0
 
     # Stop if the current archive size is bigger than the maximum (if set, i.e. > 0)
     if current_size_gb > node.max_total_gb and node.max_total_gb > 0.0:
@@ -448,7 +448,7 @@ def update_node_requests(node):
             continue
 
         # Check that there is enough space available.
-        if node.avail_gb * 2 ** 30.0 < 2.0 * req.file.size_b:
+        if node.avail_gb * 2**30.0 < 2.0 * req.file.size_b:
             log.warning(
                 'Node "%s" is full: not adding datafile "%s/%s".'
                 % (node.name, req.file.acq.name, req.file.name)
@@ -633,7 +633,7 @@ def update_node_requests(node):
 
         # Check integrity.
         if md5sum == req.file.md5sum:
-            size_mb = req.file.size_b / 2 ** 20.0
+            size_mb = req.file.size_b / 2**20.0
             trans_time = et - st
             rate = size_mb / trans_time
             log.info(
@@ -747,7 +747,7 @@ def _check_and_bundle_requests(requests, node, pull=False):
     some maximum size."""
 
     # Size to bundle transfers into (in bytes)
-    max_bundle_size = 800.0 * 2 ** 30.0
+    max_bundle_size = 800.0 * 2**30.0
 
     # Due to fixed, per-file overheads, we limit the number of files pulled
     # by a single job.  For a four hour jobspec, this works out to ten files

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "PyYAML",
         "configobj",
         "watchdog",
-        "ConcurrentLogHandler",
+        "concurrent-log-handler",
         "Click",
     ],
     entry_points="""


### PR DESCRIPTION
The Py2-only `ConcurrentLogHandler` is abandoned and no longer installable in Py3.  `concurrent-log-handler` is an up-to-date fork.

Includes pointless re-blackening to make the linting happy.