### PR TITLE
fix(auto_import): Remove unneeded bitshuffle.h5

### DIFF
--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -12,7 +12,6 @@ import os
 import datetime
 
 import bisect
-import bitshuffle.h5
 import calendar
 import configobj
 


### PR DESCRIPTION
A superfluous `import bitshuffle.h5` made alpenhornd crash on Niagara. I.e., I needed to remove this to get it to run.