### PR TITLE
fix: allow click commands with underscores

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -24,7 +24,12 @@ import chimedb.core as db
 import chimedb.data_index as di
 
 
-@click.group()
+def normalize(name):
+    return name.replace("_", "-")
+
+
+# Pass token_normalize_func to context to allow commands with underscores
+@click.group(context_settings={"token_normalize_func": normalize})
 def cli():
     """Client interface for alpenhorn. Use to request transfers, mount drives,
     check status etc."""

--- a/alpenhorn/hpss_callback.py
+++ b/alpenhorn/hpss_callback.py
@@ -26,7 +26,12 @@ log = logger.get_log()
 db.connect(read_write=True)
 
 
-@click.group()
+def normalize(name):
+    return name.replace("_", "-")
+
+
+# Pass token_normalize_func to context to allow commands with underscores
+@click.group(context_settings={"token_normalize_func": normalize})
 def cli():
     """Call back commands for updating the database from a shell script after an
     HPSS transfer."""


### PR DESCRIPTION
Using `click` version 7 caused alpenhorn to crash because it turns functions like `def push_success` into commands like `push-success`

I implemented a solution at the `click.group` level as suggested here:
https://click.palletsprojects.com/en/8.1.x/upgrading/#upgrading-to-7-0