### PR TITLE
fix(update): correct escape character in squeue command

### DIFF
--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -125,7 +125,7 @@ def slurm_jobs():
 
     user = getpass.getuser()
 
-    ret, out, err = run_command(["squeue", "-o", "%%all", "-u", user])
+    ret, out, err = run_command(["squeue", "-o", "%all", "-u", user])
     lines = out.split("\n")
     headers = lines[0].split("|")
 


### PR DESCRIPTION
I think the additional `%` character in `run_command(["squeue", "-o", "%%all", "-u", user])` was causing the problems described in #26. Presumably this escape sequence was needed in the old environment (maybe Python 2 or an old version of subprocess?), but should now be avoided.

With the double `%` character, the output (when there is a single job in the queue) is problematic:
```
ACCOUNTll
rpp-chimell
```

With a single `%` character, the output is as expected:
```
ACCOUNT|TRES_PER_NODE|MIN_CPUS|MIN_TMP_DISK|END_TIME|FEATURES|GROUP|OVER_SUBSCRIBE|JOBID|NAME|COMMENT|TIME_LIMIT|MIN_MEMORY|REQ_NODES|COMMAND|PRIORITY|QOS|REASON|ST|USER|RESERVATION|WCKEY|EXC_NODES|NICE|S:C:T|JOBID|EXEC_HOST|CPUS|NODES|DEPENDENCY|ARRAY_JOB_ID|GROUP|SOCKETS_PER_NODE|CORES_PER_SOCKET|THREADS_PER_CORE|ARRAY_TASK_ID|TIME_LEFT|TIME|NODELIST|CONTIGUOUS|PARTITION|PRIORITY|NODELIST(REASON)|START_TIME|STATE|UID|SUBMIT_TIME|LICENSES|CORE_SPEC|SCHEDNODES|WORK_DIR
rpp-chime|N/A|1|0|2024-04-09T18:05:23|(null)|chime|YES|12534745|pull_20240409T140516|/opt/slurm/bin/sbatch --export=NONE push_20240409T140516.sh|4:00:00|3046M||/gpfs/fs0/scratch/c/chime/chimedat/scripts/push_20240409T140516.sh|0.00232963985818|normal|None|R|chimedat|(null)|(null)||0|*:*:*|12534745|hpss-archive02-ib|40|1|(null)|12534745|6003614|*|*|*|N/A|3:52:55|7:05|hpss-archive02-ib|0|archivelong|10005727|hpss-archive02-ib|2024-04-09T14:05:23|RUNNING|13200129|2024-04-09T14:05:20|(null)|N/A|(null)|/gpfs/fs0/scratch/c/chime/chimedat/scripts
```