### PR TITLE
fix(scripts): Make stopping alpenhorn more robust on robots

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,12 +12,12 @@ jobs:
   lint-code:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
 
     - name: Install black
       run: pip install black

--- a/alpenhorn/hpss_callback.py
+++ b/alpenhorn/hpss_callback.py
@@ -1,5 +1,4 @@
-"""Call backs for the HPSS interface.
-"""
+"""Call backs for the HPSS interface."""
 
 # === Start Python 2/3 compatibility
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/alpenhorn/logger.py
+++ b/alpenhorn/logger.py
@@ -1,5 +1,4 @@
-"""Setup logging for alpenhorn.
-"""
+"""Setup logging for alpenhorn."""
 
 # === Start Python 2/3 compatibility
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -1,5 +1,4 @@
-"""Routines for updating the state of a node.
-"""
+"""Routines for updating the state of a node."""
 
 # === Start Python 2/3 compatibility
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/scripts/alpenhorn_cedar_robot.sh
+++ b/scripts/alpenhorn_cedar_robot.sh
@@ -20,6 +20,7 @@
 
 THIS_SCRIPT=$(basename $0)
 SCREEN=/cvmfs/soft.computecanada.ca/custom/bin/screen
+AWK=/cvmfs/soft.computecanada.ca/gentoo/2023/x86-64-v3/usr/bin/awk
 
 # NB: The inbound command ends up in $SSH_ORIGINAL_COMMAND
 
@@ -49,10 +50,19 @@ if [ "$SSH_ORIGINAL_COMMAND" = "stop" \
   ]
 then
   echo "$0: Killing alpenhornd (if running)"
-  run_screen -S alpenhornd -X quit
+
+  # Kill all screens with sessions named "alpenhornd"
+  run_screen -ls | $AWK '/[0-9]*.alpenhornd/ { print $1 }' | while read session; do
+    run_screen -S $session -X quit
+  done
+  sleep 1
+
+  # Kill all processes named "alpenhornd"
+  killall -v -9 alpenhornd
+
+  # If force-restarting, wait for termination
   if [ "$SSH_ORIGINAL_COMMAND" = "restart" ]
   then
-    # if force-restarting, wait for termination
     sleep 5
   fi
 fi

--- a/scripts/alpenhorn_nia_robot.sh
+++ b/scripts/alpenhorn_nia_robot.sh
@@ -20,6 +20,7 @@
 
 THIS_SCRIPT=$(basename $0)
 SCREEN=/usr/bin/screen
+AWK=/usr/bin/awk
 
 # NB: The inbound command ends up in $SSH_ORIGINAL_COMMAND
 
@@ -49,10 +50,20 @@ if [ "$SSH_ORIGINAL_COMMAND" = "stop" \
   ]
 then
   echo "$0: Killing alpenhornd (if running)"
+
+  # Kill all screens with sessions named "alpenhornd"
+  run_screen -ls | $AWK '/[0-9]*.alpenhornd/ { print $1 }' | while read session; do
+    run_screen -S $session -X quit
+  done
+  sleep 1
+
+  # Kill all processes named "alpenhornd"
+  killall -v -9 alpenhornd
+
+  # If force-restarting, wait for termination
   run_screen -S alpenhornd -X quit
   if [ "$SSH_ORIGINAL_COMMAND" = "restart" ]
   then
-    # if force-restarting, wait for termination
     sleep 5
   fi
 fi


### PR DESCRIPTION
This is a change I made to the robot script deployed on cedar during the last nearline I/O trouble.  The alpenhornd processes were getting stuck in I/O wait and not getting killed, leading to them piling up over time as the watchdog restarted the laggy system.

In I/O wait, these processes probably won't respond to SIGKILL, but at least this will _try_ to keep the alpnehorn processes on the robot node from getting out-of-hand.

I've made the change to the niagara script, too, but not deployed it. Because all the HPSS I/O happens in a job, there's less risk of alpenhornd getting stuck (because the queue manager will just kill it once the job goes over time).  Nevertheless, I don't see any reason not to update the niagara script, too.